### PR TITLE
Switch the default branch to "main" with minor code refactorings.

### DIFF
--- a/ads2bibdesk/__init__.py
+++ b/ads2bibdesk/__init__.py
@@ -1,2 +1,1 @@
-
-__version__ = '0.2.dev3'
+__version__ = '0.2.dev4'

--- a/ads2bibdesk/prefs.py
+++ b/ads2bibdesk/prefs.py
@@ -5,16 +5,12 @@ from configparser import ConfigParser, ExtendedInterpolation
 class Preferences(object):
 
     def __init__(self):
-        """
-        """
-
+        """Construct a Preferences object."""
         self.prefs_path = os.path.expanduser('~/.ads/ads2bibdesk.cfg')
         self.log_path = os.path.expanduser('~/.ads/ads2bibdesk.log')
         self.prefs = self._get_prefs()
 
     def _get_prefs(self):
-        """
-        """
 
         prefs = ConfigParser(interpolation=ExtendedInterpolation())
         prefs.read_string("""

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-
 The command line script can be installed via one of these commands:
 
     pip install --user .               $ from a local copy 
@@ -129,9 +128,10 @@ setup(
     keywords="bibtex astronomy ADS",
     classifiers=['Development Status :: 4 - Beta',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.6',
-                 'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
+                 'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10',
+                 'Programming Language :: Python :: 3.11',
                  "Intended Audience :: Science/Research",
                  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
                  "Operating System :: MacOS :: MacOS X",
@@ -140,7 +140,7 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': [
         'ads2bibdesk = ads2bibdesk.ads2bibdesk:main']},
-    python_requires='>=3.6, <4',
+    python_requires='>=3.8, <4',
     install_requires=['ads', 'requests', 'lxml', 'pyobjc-framework-Cocoa'],
     project_urls={'Bug Reports': 'https://github.com/r-xue/ads2bibdesk/issues',
                   'Source': 'https://github.com/r-xue/ads2bibdesk/'},


### PR DESCRIPTION
cleanup of some code style issues;
removed the reference to EOL Python versions;
verified that the package is still functional on a Python 3.11 ARM machine without Rosetta.